### PR TITLE
Support for the Lifty demo

### DIFF
--- a/resources/custom/liquidhaskell/sandbox/Tagged.lhs
+++ b/resources/custom/liquidhaskell/sandbox/Tagged.lhs
@@ -1,0 +1,114 @@
+\begin{code}
+module Tagged where 
+
+import Prelude hiding (print)
+
+data User = Chair | Alice | Bob | Default
+   deriving (Show, Eq)
+
+-- | Value tagged with a policy  
+
+{-@ data Tagged a <p :: User -> Prop> = Tagged (content :: a) @-}
+data Tagged a = Tagged a
+
+{-@ data variance Tagged  covariant contravariant @-}
+
+instance Functor Tagged where
+  fmap f (Tagged x) = Tagged (f x)
+
+instance Applicative Tagged where
+  pure  = Tagged
+  -- f (a -> b) -> f a -> f b 
+  (Tagged f) <*> (Tagged x) = Tagged (f x)
+
+instance Monad Tagged where
+  return x = Tagged x
+  (Tagged x) >>= f = f x 
+  (Tagged _) >>  t = t  
+  fail          = error
+
+{-@ instance Monad Tagged where 
+     >>= :: forall <p :: User -> Prop, f:: a -> b -> Prop>. 
+            x:Tagged <p> a
+         -> (u:a -> Tagged <p> (b <f u>))
+         -> Tagged <p> (b<f (content x)>); 
+     >>  :: x:Tagged a
+         -> Tagged b
+         -> Tagged b;
+     return :: forall <p :: User -> Prop>. a -> Tagged <p> a 
+  @-}
+
+{-@ liftM :: forall a b <p :: User -> Prop, f:: a -> b -> Prop>.
+                x: Tagged <p> a
+                -> (u:a -> b<f u>)
+                -> Tagged <p> (b<f (content x)>)
+@-}
+liftM :: Tagged a -> (a -> b) -> Tagged b
+liftM x f =  x >>= (\x' -> return (f x'))
+
+--{-@ lift :: forall a b <p :: User -> Prop, f:: a -> b -> Prop>.
+--                (u:a -> b<f u>)
+--                -> x: Tagged <p> a
+--                -> Tagged <p> (b<f (content x)>)
+-- @-}
+--lift :: (a -> b) -> Tagged a -> Tagged b
+--lift f x = bind x (\x' -> ret (f x'))
+
+--liftM2 :: (a -> b -> c) -> Tagged a -> Tagged b -> Tagged c
+--liftM2 f x y = bind x (\x' -> bind y (\y' -> ret (f x' y')))  
+
+data PaperId
+data World
+
+{- Sensitive data and policies -}
+   
+-- | Current session user
+{-@ measure sessionUser :: World -> User @-}
+sessionUser = Alice
+{-@ assume getSessionUser :: w:World -> {u:User | u == sessionUser w} @-}
+getSessionUser :: World -> User
+getSessionUser w = Alice
+
+-- | PC chair (public)
+{-@ measure chair :: World -> User @-}
+chair = Chair
+
+{-@ assume getChair :: Tagged {v:User | v == Chair} @-}
+getChair :: Tagged User
+getChair = Tagged Chair
+
+-- | Paper title (public)
+getTitle :: PaperId -> Tagged String
+getTitle pid = Tagged "Waow" -- hack for now
+
+-- | Paper authors (visible only to the chair)
+{-@ getAuthors ::  pid : PaperId -> Tagged <{\u -> u == Chair}> [User]  @-}
+getAuthors :: PaperId -> Tagged [User]
+getAuthors pid = Tagged [Alice, Bob] -- hack for now
+defaultPaperAuthors = [Default]
+
+print :: Tagged User -> Tagged String -> IO ()
+{-@ print :: forall <p :: User -> Prop>. 
+             viewer:Tagged <p> (User<p>) 
+          -> msg:Tagged <p> String 
+          -> IO () @-}
+print = undefined
+
+
+-- This is a bad type because p is at the same time co- anc contra- variant
+-- so putting it on the result type creates inconsistencies.
+{- getCurrentUser :: forall <p :: User -> Prop>.
+                      w:World -> Tagged <p> (User<p>) @-}
+
+{-@ measure currentUser :: World -> User @-}
+{- getCurrentUser :: w:World -> Tagged {v:User | v == currentUser w }@-}                      
+getCurrentUser :: Tagged User 
+getCurrentUser = undefined 
+
+
+{-@ whenUserIsChair ::forall <p :: User -> Prop>.  Tagged <{\v -> v == Chair}>[a] -> Tagged <p> [a] @-}
+whenUserIsChair :: Tagged [a] -> Tagged [a]
+whenUserIsChair t = do 
+  u <- getCurrentUser 
+  if u == Chair then t else return [] 
+\end{code}


### PR DESCRIPTION
For the Lifty demo I need few functions with Abstract Refinements.

Due to a bug, Abstract Refinements signatures do not print well and create syntactic errors. 

For now I (currently locally) import all such functions with the Tagged.lhs file. 

@ranjitjhala can you merge or can you move liquid-server at a place that I have write access? 