### PR TITLE
Add `verifySource` key listener to `LiquidDemoCtrl`

### DIFF
--- a/resources/static/js/liquid.js
+++ b/resources/static/js/liquid.js
@@ -443,7 +443,15 @@ function LiquidDemoCtrl($scope, $http, $location) {
   
   $scope.verifySource   = function(){ verifyQuery(getCheckQuery($scope));   };
   $scope.reVerifySource = function(){ verifyQuery(getRecheckQuery($scope)); };
-   
+
+  // add Ctrl + Enter keybind for verifySource
+  $scope.initKeyListener = function(){
+    document.addEventListener('keydown', e => {
+        if (e.ctrlKey && e.key === 'Enter') {
+            $scope.$apply($scope.verifySource);
+        }
+    });
+  };
 }
 
 /************************************************************************/


### PR DESCRIPTION
My original hack [on Piazza](https://piazza.com/class/lr1zj9yl963y9/post/41) was for outermost scope, but for this I tucked it into the end of the controller. I could see it making more sense as a command inside the ace editor itself, but as I'm familiar with neither angular nor ace, I didn't attempt it.